### PR TITLE
Fix for connecting via PDO to MYSQL (SSL only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For an introduction to replication lag cure and multi-master write conflicts man
 Most changes are in [Global transaction IDs](docs/BOOK/QUICKSTART-AND-EXAMPLES/GLOBAL-TRANSACTION-IDS.md) injection implementation and session consistency implementation of the [Quality Of Service filter](docs/BOOK/QUICKSTART-AND-EXAMPLES/SERVICE-LEVEL-AND-CONSISTENCY.md).
 
 * PHP7.x porting
+* SSL support for PDO (workaround using the mysqlnd_ms.ini file)
 * [New QOS session consinstency](docs/BOOK/QUICKSTART-AND-EXAMPLES/SERVICE-LEVEL-AND-CONSISTENCY.md) and [transaction id injection](docs/BOOK/QUICKSTART-AND-EXAMPLES/GLOBAL-TRANSACTION-IDS.md)
 * [Server side read consistency](docs/BOOK/QUICKSTART-AND-EXAMPLES/SERVICE-LEVEL-AND-CONSISTENCY.md#server-side-read-consistency) (mysql >= 5.7.6 with --session-track-gtids=OWN_GTID)
   * Mysql native built-in read consistency 

--- a/mysqlnd_ms.c
+++ b/mysqlnd_ms.c
@@ -3478,6 +3478,7 @@ MYSQLND_METHOD(mysqlnd_ms, connect)(MYSQLND_CONN_DATA * conn,
 
 	if (FALSE == section_found && !the_section) {
 		DBG_INF("section not found");
+
 		ret = MS_CALL_ORIGINAL_CONN_DATA_METHOD(connect)(conn, MYSQLND_MS_CONN_A_STRING(host), MYSQLND_MS_CONN_A_STRING(user), MYSQLND_MS_CONN_A_STRINGL(passwd), MYSQLND_MS_CONN_A_STRINGL(db), port, MYSQLND_MS_CONN_A_STRING(socket), mysql_flags TSRMLS_CC);
 	} else {
 		zend_bool value_exists = FALSE;

--- a/mysqlnd_ms.c
+++ b/mysqlnd_ms.c
@@ -2562,7 +2562,7 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CA_NAME". Cannot be a list/hash' . Stopping");
 			failures++;
 		} else if (value_exists && ssl_ca) {
-			MYSQLND_MS_S_TO_CONN_STRINGL(cred.ssl_ca, ssl_ca, strlen(ssl_ca));
+			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_ca, ssl_ca);
 		}
 
 		// SSL cipher support
@@ -2573,7 +2573,7 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CIPHER_NAME". Cannot be a list/hash' . Stopping");
 			failures++;
 		} else if (value_exists && ssl_cipher) {
-			MYSQLND_MS_S_TO_CONN_STRINGL(cred.ssl_cipher, ssl_cipher, strlen(ssl_cipher));
+			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_cipher, ssl_cipher);
         }
 
 		host_to_use = mysqlnd_ms_config_json_string_from_section(subsection, SECT_HOST_NAME, sizeof(SECT_HOST_NAME) - 1, 0,

--- a/mysqlnd_ms.c
+++ b/mysqlnd_ms.c
@@ -576,9 +576,9 @@ mysqlnd_ms_connect_to_host_aux_elm(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_
 
 		MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->db, cred->db, conn->persistent);
 
-        MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->ssl_ca, cred->ssl_ca, conn->persistent);
+        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_ca, cred->ssl_ca, conn->persistent);
 
-        MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->ssl_cipher, cred->ssl_cipher, conn->persistent);
+        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_cipher, cred->ssl_cipher, conn->persistent);
 
         (*new_element)->connect_flags = mysql_flags;
 

--- a/mysqlnd_ms.c
+++ b/mysqlnd_ms.c
@@ -386,7 +386,11 @@ mysqlnd_ms_lazy_connect(MYSQLND_MS_LIST_DATA * element, zend_bool master TSRMLS_
 										MYSQLND_MS_ERROR_PREFIX " Couldn't force charset to '%s'",
 										(*proxy_conn_data)->server_charset->name);
 	} else {
-
+		// TODO: GALVIN Changes for ssl certificates
+        MS_CALL_ORIGINAL_CONN_DATA_METHOD(ssl_set)(connection, NULL, NULL,
+                                                   MYSQLND_MS_CONN_STRING(element->ssl_ca),
+                                                         NULL,
+                                                   MYSQLND_MS_CONN_STRING(element->ssl_cipher));
 
 		ret = MS_CALL_ORIGINAL_CONN_DATA_METHOD(connect)(connection, MYSQLND_MS_CONN_A_CSTRING(element->host), MYSQLND_MS_CONN_A_CSTRING(element->user),
 				MYSQLND_MS_CONN_A_CSTRINGL(element->passwd),
@@ -539,6 +543,12 @@ mysqlnd_ms_connect_to_host_aux_elm(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_
 			mysqlnd_ms_client_n_php_error(&MYSQLND_MS_ERROR_INFO(conn), CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_ERROR TSRMLS_CC,
 						MYSQLND_MS_ERROR_PREFIX " Couldn't force charset to '%s'", (*proxy_conn_data)->server_charset->name);
 		} else {
+			// TODO: GALVIN Changes for ssl certificates
+			MS_CALL_ORIGINAL_CONN_DATA_METHOD(ssl_set)(conn, NULL, NULL,
+													   MYSQLND_MS_CONN_STRING(cred->ssl_ca),
+													   NULL,
+													   MYSQLND_MS_CONN_STRING(cred->ssl_cipher));
+
 			ret = MS_CALL_ORIGINAL_CONN_DATA_METHOD(connect)(conn, MYSQLND_MS_CONN_A_CSTRING(host), MYSQLND_MS_CONN_A_CSTRING(cred->user), MYSQLND_MS_CONN_A_CSTRINGL(cred->passwd), MYSQLND_MS_CONN_A_CSTRINGL(cred->db),
 															 cred->port, MYSQLND_MS_CONN_A_CSTRING(cred->socket), mysql_flags TSRMLS_CC);
 		}
@@ -566,9 +576,13 @@ mysqlnd_ms_connect_to_host_aux_elm(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_
 
 		MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->db, cred->db, conn->persistent);
 
-		(*new_element)->connect_flags = mysql_flags;
+        MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->ssl_ca, cred->ssl_ca, conn->persistent);
 
-		MYSQLND_MS_CONN_STRING_DUP((*new_element)->socket, cred->socket, conn->persistent);
+        MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->ssl_cipher, cred->ssl_cipher, conn->persistent);
+
+        (*new_element)->connect_flags = mysql_flags;
+
+        MYSQLND_MS_CONN_STRING_DUP((*new_element)->socket, cred->socket, conn->persistent);
 
 		(*new_element)->emulated_scheme_len = mysqlnd_ms_get_scheme_from_list_data((*new_element), &(*new_element)->emulated_scheme,
 																					persistent TSRMLS_CC);
@@ -2450,6 +2464,10 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 		char * pass_to_use = NULL;
 		char * db_to_use = NULL;
 		char * host_to_use = NULL;
+
+		char * ssl_ca = NULL;
+		char * ssl_cipher = NULL;
+
 		MYSQLND_MS_CONN_DV_STRING(host);
 		int64_t port, flags;
 
@@ -2536,6 +2554,28 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 			MYSQLND_MS_S_TO_CONN_STRINGL(cred.db, db_to_use, strlen(db_to_use));
 		}
 
+		// CA support
+		ssl_ca = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CA_NAME, sizeof(SECT_SSL_CA_NAME) - 1, 0,
+															   &value_exists, &is_list_value TSRMLS_CC);
+		if (is_list_value) {
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
+					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CA_NAME". Cannot be a list/hash' . Stopping");
+			failures++;
+		} else if (value_exists && ssl_ca) {
+			MYSQLND_MS_S_TO_CONN_STRINGL(cred.ssl_ca, ssl_ca, strlen(ssl_ca));
+		}
+
+		// SSL cipher support
+		ssl_cipher = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CIPHER_NAME, sizeof(SECT_SSL_CIPHER_NAME) - 1, 0,
+															   &value_exists, &is_list_value TSRMLS_CC);
+		if (is_list_value) {
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
+					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CIPHER_NAME". Cannot be a list/hash' . Stopping");
+			failures++;
+		} else if (value_exists && ssl_cipher) {
+			MYSQLND_MS_S_TO_CONN_STRINGL(cred.ssl_cipher, ssl_cipher, strlen(ssl_cipher));
+        }
+
 		host_to_use = mysqlnd_ms_config_json_string_from_section(subsection, SECT_HOST_NAME, sizeof(SECT_HOST_NAME) - 1, 0,
 														  &value_exists, &is_list_value TSRMLS_CC);
 		if (is_list_value) {
@@ -2591,6 +2631,13 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 			}
 		}
 		i++; /* to pass only the first conn handle */
+
+		if (ssl_ca) {
+			mnd_efree(ssl_ca);
+		}
+		if (ssl_cipher) {
+			mnd_efree(ssl_cipher);
+		}
 
 		if (socket_to_use) {
 			mnd_efree(socket_to_use);
@@ -5747,9 +5794,9 @@ mysqlnd_ms_protocol_rset_header_read(_MS_PROTOCOL_CONN_READ_D TSRMLS_DC)
 		case 0x00:
 			DBG_INF("UPSERT");
 			/*
-			 * Verrà chiamata direttamente la read dell'OK
-			 * (attenzione il byte iniziale è già stato letto)
-			 * L'OK avrà le informazioni di SESSION_TRACK le informazioni
+			 * Verrï¿½ chiamata direttamente la read dell'OK
+			 * (attenzione il byte iniziale ï¿½ giï¿½ stato letto)
+			 * L'OK avrï¿½ le informazioni di SESSION_TRACK le informazioni
 			 * I valori estratti verranno copiati nel pacchetto di destinazione
 			 * il message verra copiato in info_or_local_file e poi messo a NULL
 			 *

--- a/mysqlnd_ms.c
+++ b/mysqlnd_ms.c
@@ -5859,9 +5859,9 @@ mysqlnd_ms_protocol_rset_header_read(_MS_PROTOCOL_CONN_READ_D TSRMLS_DC)
 		case 0x00:
 			DBG_INF("UPSERT");
 			/*
-			 * Verr� chiamata direttamente la read dell'OK
-			 * (attenzione il byte iniziale � gi� stato letto)
-			 * L'OK avr� le informazioni di SESSION_TRACK le informazioni
+			 * Verrà chiamata direttamente la read dell'OK
+			 * (attenzione il byte iniziale è già stato letto)
+			 * L'OK avrà le informazioni di SESSION_TRACK le informazioni
 			 * I valori estratti verranno copiati nel pacchetto di destinazione
 			 * il message verra copiato in info_or_local_file e poi messo a NULL
 			 *

--- a/mysqlnd_ms.c
+++ b/mysqlnd_ms.c
@@ -386,7 +386,6 @@ mysqlnd_ms_lazy_connect(MYSQLND_MS_LIST_DATA * element, zend_bool master TSRMLS_
 										MYSQLND_MS_ERROR_PREFIX " Couldn't force charset to '%s'",
 										(*proxy_conn_data)->server_charset->name);
 	} else {
-		// TODO: GALVIN Changes for ssl certificates
         MS_CALL_ORIGINAL_CONN_DATA_METHOD(ssl_set)(connection,
                                                    MYSQLND_MS_CONN_STRING(element->ssl_key),
                                                    MYSQLND_MS_CONN_STRING(element->ssl_cert),
@@ -545,10 +544,9 @@ mysqlnd_ms_connect_to_host_aux_elm(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_
 			mysqlnd_ms_client_n_php_error(&MYSQLND_MS_ERROR_INFO(conn), CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_ERROR TSRMLS_CC,
 						MYSQLND_MS_ERROR_PREFIX " Couldn't force charset to '%s'", (*proxy_conn_data)->server_charset->name);
 		} else {
-			// TODO: GALVIN Changes for ssl certificates
 			MS_CALL_ORIGINAL_CONN_DATA_METHOD(ssl_set)(conn,
-                                                       MYSQLND_MS_CONN_STRING(cred->ssl_key),
-                                                       MYSQLND_MS_CONN_STRING(cred->ssl_cert),
+													   MYSQLND_MS_CONN_STRING(cred->ssl_key),
+													   MYSQLND_MS_CONN_STRING(cred->ssl_cert),
 													   MYSQLND_MS_CONN_STRING(cred->ssl_ca),
 													   MYSQLND_MS_CONN_STRING(cred->ssl_capath),
 													   MYSQLND_MS_CONN_STRING(cred->ssl_cipher));
@@ -580,15 +578,15 @@ mysqlnd_ms_connect_to_host_aux_elm(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_
 
 		MYSQLND_MS_CONN_STRINGL_DUP((*new_element)->db, cred->db, conn->persistent);
 
-        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_key, cred->ssl_key, conn->persistent);
-        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_cert, cred->ssl_cert, conn->persistent);
-        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_ca, cred->ssl_ca, conn->persistent);
-        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_capath, cred->ssl_capath, conn->persistent);
-        MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_cipher, cred->ssl_cipher, conn->persistent);
+		MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_key, cred->ssl_key, conn->persistent);
+		MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_cert, cred->ssl_cert, conn->persistent);
+		MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_ca, cred->ssl_ca, conn->persistent);
+		MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_capath, cred->ssl_capath, conn->persistent);
+		MYSQLND_MS_CONN_STRING_DUP((*new_element)->ssl_cipher, cred->ssl_cipher, conn->persistent);
 
-        (*new_element)->connect_flags = mysql_flags;
+		(*new_element)->connect_flags = mysql_flags;
 
-        MYSQLND_MS_CONN_STRING_DUP((*new_element)->socket, cred->socket, conn->persistent);
+		MYSQLND_MS_CONN_STRING_DUP((*new_element)->socket, cred->socket, conn->persistent);
 
 		(*new_element)->emulated_scheme_len = mysqlnd_ms_get_scheme_from_list_data((*new_element), &(*new_element)->emulated_scheme,
 																					persistent TSRMLS_CC);
@@ -2471,11 +2469,11 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 		char * db_to_use = NULL;
 		char * host_to_use = NULL;
 
-        char * ssl_key = NULL;
-        char * ssl_cert = NULL;
-        char * ssl_ca = NULL;
-        char * ssl_capath = NULL;
-		char * ssl_cipher = NULL;
+		char *ssl_key = NULL;
+		char *ssl_cert = NULL;
+		char *ssl_ca = NULL;
+		char *ssl_capath = NULL;
+		char *ssl_cipher = NULL;
 
 		MYSQLND_MS_CONN_DV_STRING(host);
 		int64_t port, flags;
@@ -2563,60 +2561,75 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 			MYSQLND_MS_S_TO_CONN_STRINGL(cred.db, db_to_use, strlen(db_to_use));
 		}
 
-        // SSL KEY support
-        ssl_key = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_KEY_NAME, sizeof(SECT_SSL_KEY_NAME) - 1, 0,
-                                                            &value_exists, &is_list_value TSRMLS_CC);
-        if (is_list_value) {
-            mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
-                    MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_KEY_NAME". Cannot be a list/hash' . Stopping");
-            failures++;
-        } else if (value_exists && ssl_key) {
-            MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_key, ssl_key);
-        }
-
-        // SSL CERT support
-        ssl_cert = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CERT_NAME, sizeof(SECT_SSL_CERT_NAME) - 1, 0,
-                                                             &value_exists, &is_list_value TSRMLS_CC);
-        if (is_list_value) {
-            mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
-                    MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CERT_NAME". Cannot be a list/hash' . Stopping");
-            failures++;
-        } else if (value_exists && ssl_cert) {
-            MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_cert, ssl_cert);
-        }
-
-        // SSL CA support
-		ssl_ca = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CA_NAME, sizeof(SECT_SSL_CA_NAME) - 1, 0,
-															   &value_exists, &is_list_value TSRMLS_CC);
+		// SSL KEY support
+		ssl_key = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_KEY_NAME,
+															 sizeof(SECT_SSL_KEY_NAME) - 1, 0,
+															 &value_exists, &is_list_value
+		TSRMLS_CC);
 		if (is_list_value) {
-			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR
+			TSRMLS_CC,
+					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_KEY_NAME". Cannot be a list/hash' . Stopping");
+			failures++;
+		} else if (value_exists && ssl_key) {
+			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_key, ssl_key);
+		}
+
+		// SSL CERT support
+		ssl_cert = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CERT_NAME,
+															  sizeof(SECT_SSL_CERT_NAME) - 1, 0,
+															  &value_exists, &is_list_value
+		TSRMLS_CC);
+		if (is_list_value) {
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR
+			TSRMLS_CC,
+					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CERT_NAME". Cannot be a list/hash' . Stopping");
+			failures++;
+		} else if (value_exists && ssl_cert) {
+			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_cert, ssl_cert);
+		}
+
+		// SSL CA support
+		ssl_ca = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CA_NAME, sizeof(SECT_SSL_CA_NAME) - 1,
+															0,
+															&value_exists, &is_list_value
+		TSRMLS_CC);
+		if (is_list_value) {
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR
+			TSRMLS_CC,
 					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CA_NAME". Cannot be a list/hash' . Stopping");
 			failures++;
 		} else if (value_exists && ssl_ca) {
 			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_ca, ssl_ca);
 		}
 
-        // SSL CAPATH support
-        ssl_capath = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CAPATH_NAME, sizeof(SECT_SSL_CAPATH_NAME) - 1, 0,
-                                                            &value_exists, &is_list_value TSRMLS_CC);
-        if (is_list_value) {
-            mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
-                    MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CAPATH_NAME". Cannot be a list/hash' . Stopping");
-            failures++;
-        } else if (value_exists && ssl_capath) {
-            MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_capath, ssl_capath);
-        }
-
-        // SSL cipher support
-		ssl_cipher = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CIPHER_NAME, sizeof(SECT_SSL_CIPHER_NAME) - 1, 0,
-															   &value_exists, &is_list_value TSRMLS_CC);
+		// SSL CAPATH support
+		ssl_capath = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CAPATH_NAME,
+																sizeof(SECT_SSL_CAPATH_NAME) - 1, 0,
+																&value_exists, &is_list_value
+		TSRMLS_CC);
 		if (is_list_value) {
-			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR TSRMLS_CC,
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR
+			TSRMLS_CC,
+					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CAPATH_NAME". Cannot be a list/hash' . Stopping");
+			failures++;
+		} else if (value_exists && ssl_capath) {
+			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_capath, ssl_capath);
+		}
+
+		// SSL cipher support
+		ssl_cipher = mysqlnd_ms_config_json_string_from_section(subsection, SECT_SSL_CIPHER_NAME,
+																sizeof(SECT_SSL_CIPHER_NAME) - 1, 0,
+																&value_exists, &is_list_value
+		TSRMLS_CC);
+		if (is_list_value) {
+			mysqlnd_ms_client_n_php_error(error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE, E_RECOVERABLE_ERROR
+			TSRMLS_CC,
 					MYSQLND_MS_ERROR_PREFIX " Invalid value for "SECT_SSL_CIPHER_NAME". Cannot be a list/hash' . Stopping");
 			failures++;
 		} else if (value_exists && ssl_cipher) {
 			MYSQLND_MS_S_TO_CONN_STRING(cred.ssl_cipher, ssl_cipher);
-        }
+		}
 
 		host_to_use = mysqlnd_ms_config_json_string_from_section(subsection, SECT_HOST_NAME, sizeof(SECT_HOST_NAME) - 1, 0,
 														  &value_exists, &is_list_value TSRMLS_CC);
@@ -2674,19 +2687,19 @@ mysqlnd_ms_connect_to_host(MYSQLND_CONN_DATA * proxy_conn, MYSQLND_CONN_DATA * c
 		}
 		i++; /* to pass only the first conn handle */
 
-        if (ssl_key) {
-            mnd_efree(ssl_key);
-        }
-        if (ssl_cert) {
-            mnd_efree(ssl_cert);
-        }
-        if (ssl_ca) {
+		if (ssl_key) {
+			mnd_efree(ssl_key);
+		}
+		if (ssl_cert) {
+			mnd_efree(ssl_cert);
+		}
+		if (ssl_ca) {
 			mnd_efree(ssl_ca);
 		}
-        if (ssl_capath) {
-            mnd_efree(ssl_capath);
-        }
-        if (ssl_cipher) {
+		if (ssl_capath) {
+			mnd_efree(ssl_capath);
+		}
+		if (ssl_cipher) {
 			mnd_efree(ssl_cipher);
 		}
 

--- a/mysqlnd_ms_config_json.c
+++ b/mysqlnd_ms_config_json.c
@@ -572,7 +572,7 @@ mysqlnd_ms_config_json_section_is_object_list(struct st_mysqlnd_ms_config_json_e
 /* {{{ mysqlnd_ms_config_json_next_sub_section */
 PHP_MYSQLND_MS_API struct st_mysqlnd_ms_config_json_entry *
 mysqlnd_ms_config_json_next_sub_section(struct st_mysqlnd_ms_config_json_entry * main_section,
-										char ** section_name, size_t * section_name_len, _ms_ulong * nkey TSRMLS_DC)
+										char ** section_name, size_t * section_name_len, ulong * nkey TSRMLS_DC)
 {
 	struct st_mysqlnd_ms_config_json_entry * ret = NULL;
 	struct st_mysqlnd_ms_config_json_entry _ms_p_zval * entry;

--- a/mysqlnd_ms_enum_n_def.h
+++ b/mysqlnd_ms_enum_n_def.h
@@ -542,6 +542,8 @@ extern struct st_mysqlnd_conn_methods * ms_orig_mysqlnd_conn_handle_methods;
 #define SECT_PASS_NAME						"password"
 #define SECT_DB_NAME						"db"
 #define SECT_CONNECT_FLAGS_NAME				"connect_flags"
+#define SECT_SSL_CA_NAME					"ssl_ca"
+#define SECT_SSL_CIPHER_NAME				"ssl_cipher"
 #define SECT_FILTER_PRIORITY_NAME 			"priority"
 #define SECT_FILTER_NAME					"filters"
 #define SECT_USER_CALLBACK					"callback"
@@ -764,6 +766,10 @@ typedef struct st_mysqlnd_ms_list_data
 	char * emulated_scheme;
 	size_t emulated_scheme_len;
 	zend_bool persistent;
+
+	MYSQLND_MS_CONN_DV_STRING(ssl_ca);
+	MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
+
 } MYSQLND_MS_LIST_DATA;
 
 
@@ -1092,6 +1098,9 @@ typedef struct st_mysqlnd_ms_conn_data
 		MYSQLND_MS_CONN_DV_STRING(socket);
 		MYSQLND_MS_CONN_DV_STRINGL(db);
 		unsigned long mysql_flags;
+
+		MYSQLND_MS_CONN_DV_STRING(ssl_ca);
+		MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
 	} cred;
 
 	/* per connection trx context set on proxy conn and all others */

--- a/mysqlnd_ms_enum_n_def.h
+++ b/mysqlnd_ms_enum_n_def.h
@@ -542,7 +542,10 @@ extern struct st_mysqlnd_conn_methods * ms_orig_mysqlnd_conn_handle_methods;
 #define SECT_PASS_NAME						"password"
 #define SECT_DB_NAME						"db"
 #define SECT_CONNECT_FLAGS_NAME				"connect_flags"
+#define SECT_SSL_KEY_NAME					"ssl_key"
+#define SECT_SSL_CERT_NAME					"ssl_cert"
 #define SECT_SSL_CA_NAME					"ssl_ca"
+#define SECT_SSL_CAPATH_NAME				"ssl_capath"
 #define SECT_SSL_CIPHER_NAME				"ssl_cipher"
 #define SECT_FILTER_PRIORITY_NAME 			"priority"
 #define SECT_FILTER_NAME					"filters"
@@ -767,7 +770,10 @@ typedef struct st_mysqlnd_ms_list_data
 	size_t emulated_scheme_len;
 	zend_bool persistent;
 
-	MYSQLND_MS_CONN_DV_STRING(ssl_ca);
+    MYSQLND_MS_CONN_DV_STRING(ssl_key);
+    MYSQLND_MS_CONN_DV_STRING(ssl_cert);
+    MYSQLND_MS_CONN_DV_STRING(ssl_ca);
+    MYSQLND_MS_CONN_DV_STRING(ssl_capath);
 	MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
 
 } MYSQLND_MS_LIST_DATA;
@@ -1099,7 +1105,10 @@ typedef struct st_mysqlnd_ms_conn_data
 		MYSQLND_MS_CONN_DV_STRINGL(db);
 		unsigned long mysql_flags;
 
-		MYSQLND_MS_CONN_DV_STRING(ssl_ca);
+        MYSQLND_MS_CONN_DV_STRING(ssl_key);
+        MYSQLND_MS_CONN_DV_STRING(ssl_cert);
+        MYSQLND_MS_CONN_DV_STRING(ssl_ca);
+		MYSQLND_MS_CONN_DV_STRING(ssl_capath);
 		MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
 	} cred;
 

--- a/mysqlnd_ms_enum_n_def.h
+++ b/mysqlnd_ms_enum_n_def.h
@@ -542,11 +542,11 @@ extern struct st_mysqlnd_conn_methods * ms_orig_mysqlnd_conn_handle_methods;
 #define SECT_PASS_NAME						"password"
 #define SECT_DB_NAME						"db"
 #define SECT_CONNECT_FLAGS_NAME				"connect_flags"
-#define SECT_SSL_KEY_NAME					"ssl_key"
-#define SECT_SSL_CERT_NAME					"ssl_cert"
-#define SECT_SSL_CA_NAME					"ssl_ca"
-#define SECT_SSL_CAPATH_NAME				"ssl_capath"
-#define SECT_SSL_CIPHER_NAME				"ssl_cipher"
+#define SECT_SSL_KEY_NAME                   "ssl_key"
+#define SECT_SSL_CERT_NAME                  "ssl_cert"
+#define SECT_SSL_CA_NAME                    "ssl_ca"
+#define SECT_SSL_CAPATH_NAME                "ssl_capath"
+#define SECT_SSL_CIPHER_NAME                "ssl_cipher"
 #define SECT_FILTER_PRIORITY_NAME 			"priority"
 #define SECT_FILTER_NAME					"filters"
 #define SECT_USER_CALLBACK					"callback"
@@ -774,7 +774,7 @@ typedef struct st_mysqlnd_ms_list_data
     MYSQLND_MS_CONN_DV_STRING(ssl_cert);
     MYSQLND_MS_CONN_DV_STRING(ssl_ca);
     MYSQLND_MS_CONN_DV_STRING(ssl_capath);
-	MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
+    MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
 
 } MYSQLND_MS_LIST_DATA;
 
@@ -1108,8 +1108,8 @@ typedef struct st_mysqlnd_ms_conn_data
         MYSQLND_MS_CONN_DV_STRING(ssl_key);
         MYSQLND_MS_CONN_DV_STRING(ssl_cert);
         MYSQLND_MS_CONN_DV_STRING(ssl_ca);
-		MYSQLND_MS_CONN_DV_STRING(ssl_capath);
-		MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
+        MYSQLND_MS_CONN_DV_STRING(ssl_capath);
+        MYSQLND_MS_CONN_DV_STRING(ssl_cipher);
 	} cred;
 
 	/* per connection trx context set on proxy conn and all others */


### PR DESCRIPTION
The PDO_MYSQL driver unfortunately requires the SSL to be set prior to any mysql connection being made.  For maximum flexibility, this change allows the following in the ini file:

ssl_key
ssl_cert
ssl_ca
ssl_capath
ssl_cipher 

to be defined as part of the ini to properly connect to a MySQL instance that REQUIRES SSL.

This fix also contains a compilation issue when compiling under OSX.

Reference:

https://stackoverflow.com/questions/30873272/php-pdo-mysql-mysqlnd-ms-not-connecting-with-ssl